### PR TITLE
Don't log or display full phone numbers

### DIFF
--- a/hotline/events/templates/events/numbers.html
+++ b/hotline/events/templates/events/numbers.html
@@ -56,7 +56,7 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th>Number</th>
+          <th>Number (last four)</th>
           <th>Verified</th>
           <th></th>
         </tr>
@@ -65,7 +65,7 @@
         {% for member in members %}
         <tr>
           <td>{{member.name|e}}</td>
-          <td>{{member.number|e|phone}}</td>
+          <td>{{member.number[-4:]}}</td>
           <th>{{member.verified}}</th>
           <th class="has-text-right">
             {% if g.user.super_admin and not member.verified %}

--- a/hotline/events/templates/events/numbers.html
+++ b/hotline/events/templates/events/numbers.html
@@ -56,7 +56,6 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th>Number (last four)</th>
           <th>Verified</th>
           <th></th>
         </tr>
@@ -65,7 +64,6 @@
         {% for member in members %}
         <tr>
           <td>{{member.name|e}}</td>
-          <td>{{member.number[-4:]}}</td>
           <th>{{member.verified}}</th>
           <th class="has-text-right">
             {% if g.user.super_admin and not member.verified %}

--- a/hotline/telephony/lowlevel.py
+++ b/hotline/telephony/lowlevel.py
@@ -24,6 +24,9 @@ from google.api_core import retry
 from hotline import injector
 
 
+logger = logging.getLogger(__name__)
+
+
 def normalize_number(value: str, country: str = "US") -> str:
     number = phonenumbers.parse(value, country)
     return phonenumbers.format_number(number, phonenumbers.PhoneNumberFormat.E164)
@@ -131,7 +134,7 @@ def get_number_info(number: str, client: nexmo.Client) -> dict:
 
 
 def _send_sms_retry_predicate(error):
-    logging.exception("Error during SMS send")
+    logger.exception("Error during SMS send")
     if isinstance(error, nexmo.ClientError) and "Throughput Rate Exceeded" in str(
         error
     ):
@@ -154,7 +157,8 @@ def send_sms(sender: str, to: str, message: str, client: nexmo.Client) -> dict:
     # Nexmo is apparently picky about + being in the sender.
     sender = sender.strip("+")
 
-    logging.info(f"Sending from {sender} to {to} message length {len(message)}")
+    # TODO NZ: Log caller name instead of {to} number.
+    logger.info(f"Sending from {sender} message length {len(message)}")
 
     resp = client.send_message({"from": sender, "to": to, "text": message})
 

--- a/hotline/telephony/voice.py
+++ b/hotline/telephony/voice.py
@@ -93,9 +93,11 @@ def handle_inbound_call(
             }
         )
 
+    # TODO NZ: log name instead of number.
+    # Last four digits of number is {reporter_number[-4:]}
     audit_log.log(
         audit_log.Kind.VOICE_CONVERSATION_STARTED,
-        description=f"A new voice conversation was started. UUID is {conversation_uuid[-12:]}. Last four digits of number is {reporter_number[-4:]}",
+        description=f"A new voice conversation was started. UUID is {conversation_uuid[-12:]}.",
         event=event,
         reporter_number=reporter_number,
     )

--- a/hotline/telephony/webhandlers.py
+++ b/hotline/telephony/webhandlers.py
@@ -19,6 +19,8 @@ import hotline.database.ext
 from hotline import csrf, injector
 from hotline.telephony import lowlevel, verification, voice
 
+logger = logging.getLogger(__name__)
+
 blueprint = flask.Blueprint("telephony", __name__)
 hotline.database.ext.init_app(blueprint)
 
@@ -28,8 +30,9 @@ hotline.database.ext.init_app(blueprint)
 def inbound_sms():
     message = flask.request.get_json()
 
-    from_number_last_four = message['msisdn'][-4:]
-    logging.info(f"Handling message from {from_number_last_four} to {message['to']}")
+    # TODO NZ: log member name here instead of phone number
+    # from_number_last_four = message['msisdn'][-4:]
+    logger.info(f"Handling a message to {message['to']}")
 
     user_number = lowlevel.normalize_e164_number(message["msisdn"])
     relay_number = lowlevel.normalize_e164_number(message["to"])

--- a/hotline/telephony/webhandlers.py
+++ b/hotline/telephony/webhandlers.py
@@ -28,7 +28,8 @@ hotline.database.ext.init_app(blueprint)
 def inbound_sms():
     message = flask.request.get_json()
 
-    logging.info(f"Handling message from {message['msisdn']} to {message['to']}")
+    from_number_last_four = message['msisdn'][-4:]
+    logging.info(f"Handling message from {from_number_last_four} to {message['to']}")
 
     user_number = lowlevel.normalize_e164_number(message["msisdn"])
     relay_number = lowlevel.normalize_e164_number(message["to"])


### PR DESCRIPTION
When someone contacts the hotline, don't log or display their full phone number.

In the future, modify logging to log usernames or database ids instead.