### PR TITLE
Fix hotline calls coming from an unverified number

### DIFF
--- a/hotline/telephony/voice.py
+++ b/hotline/telephony/voice.py
@@ -86,12 +86,15 @@ def handle_inbound_call(
         }
     )
 
+    # Nexmo is apparently picky about + being in the from field.
+    from_number = event.primary_number.strip("+")
+
     # Add all of the event members to the conference call.
     for member in event_members:
         client.create_call(
             {
                 "to": [{"type": "phone", "number": member.number}],
-                "from": {"type": "phone", "number": event.primary_number},
+                "from": {"type": "phone", "number": from_number},
                 "answer_url": [
                     f"https://{host}/telephony/connect-to-conference/{conversation_uuid}/{call_uuid}"
                 ],

--- a/tests/telephony/helpers.py
+++ b/tests/telephony/helpers.py
@@ -3,7 +3,7 @@ from hotline.database import models as db
 
 def create_event(create_primary_number=True):
     number = db.Number()
-    number.number = "5678"
+    number.number = "+5678"
     number.country = "US"
     number.features = ""
     number.save()

--- a/tests/telephony/test_verification.py
+++ b/tests/telephony/test_verification.py
@@ -29,7 +29,7 @@ def test_start_member_verification(sleep, database):
     )
 
     client.send_message.assert_called_once_with(
-        {"from": event.primary_number, "to": member.number, "text": expected_msg}
+        {"from": "5678", "to": member.number, "text": expected_msg}
     )
 
 
@@ -84,7 +84,7 @@ def test_handle_verification_affirmative_message(sleep, database):
 
         expected_msg = "Thank you, your number is confirmed."
         client.send_message.assert_called_with(
-            {"from": event.primary_number, "to": member.number, "text": expected_msg}
+            {"from": "5678", "to": member.number, "text": expected_msg}
         )
 
 

--- a/tests/telephony/test_voice.py
+++ b/tests/telephony/test_voice.py
@@ -25,7 +25,7 @@ def test_handle_inbound_call_no_event(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -46,7 +46,7 @@ def test_handle_inbound_call_blocked(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -65,7 +65,7 @@ def test_handle_inbound_call_no_members(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -84,7 +84,7 @@ def test_handle_inbound_call_non_member_doesnt_connect(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234567",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -104,7 +104,7 @@ def test_handle_inbound_call(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number=caller.number,
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -144,7 +144,7 @@ def test_handle_inbound_call_custom_greeting(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number=caller.number,
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -160,7 +160,7 @@ def test_handle_member_answer_no_event(database):
     nexmo_client = mock.create_autospec(nexmo.Client)
 
     ncco = voice.handle_member_answer(
-        event_number="5678",
+        event_number="+5678",
         member_number="202",
         origin_conversation_uuid="conversation",
         origin_call_uuid="call",
@@ -179,7 +179,7 @@ def test_handle_member_answer(database):
     nexmo_client = mock.create_autospec(nexmo.Client)
 
     ncco = voice.handle_member_answer(
-        event_number="5678",
+        event_number="+5678",
         member_number="202",
         origin_conversation_uuid="conversation",
         origin_call_uuid="call",


### PR DESCRIPTION
Nexmo requires the from number to contain no leading zeros and no symbols.

This strips the plus symbol from the from phone number, allowing the call to come through from the hotline number instead of an unverified number.

This fix will need to be tested in the future with international numbers.

Closes #4 